### PR TITLE
add first searcher

### DIFF
--- a/src/search/digit.ts
+++ b/src/search/digit.ts
@@ -1,0 +1,27 @@
+// Searcher is the most basic implementation of detecting a number. It simply
+// loogs for digits in the given string and returns them. Note that str must not
+// contain any whitespace.
+export function Searcher(str: string): { found: boolean; match: number } {
+  let f: boolean = false;
+  let m: number = 0;
+
+  let y: any = str.match(/\d+/);
+  {
+    if (y === null) {
+      return { found: f, match: m };
+    }
+    if (y.length != 1) {
+      return { found: f, match: m };
+    }
+  }
+
+  {
+    f = true;
+    m = parseInt(y[0]);
+  }
+
+  return { found: f, match: m };
+}
+
+// float
+// [\d]+[\.]+[\d]

--- a/src/search/digit.ts
+++ b/src/search/digit.ts
@@ -22,6 +22,3 @@ export function Searcher(str: string): { found: boolean; match: number } {
 
   return { found: f, match: m };
 }
-
-// float
-// [\d]+[\.]+[\d]

--- a/src/search/index.test.ts
+++ b/src/search/index.test.ts
@@ -3,11 +3,42 @@ import * as search from ".";
 test("empty string", () => {
   let s: string = "";
 
-  expect(search.Search(s)).toHaveLength(0);
+  let l: number[] = search.Search(s);
+
+  expect(l).toHaveLength(0);
 });
 
 test("random string", () => {
   let s: string = "foo bar";
 
-  expect(search.Search(s)).toHaveLength(0);
+  let l: number[] = search.Search(s);
+
+  expect(l).toHaveLength(0);
+});
+
+test("with digit", () => {
+  let s: string = "foo 3 bar";
+
+  let l: number[] = search.Search(s);
+
+  expect(l).toHaveLength(1);
+  expect(l).toContain(3);
+});
+
+test("with digit", () => {
+  let s: string = "20 foo bar";
+
+  let l: number[] = search.Search(s);
+
+  expect(l).toHaveLength(1);
+  expect(l).toContain(20);
+});
+
+test("with digit", () => {
+  let s: string = "foo bar 666";
+
+  let l: number[] = search.Search(s);
+
+  expect(l).toHaveLength(1);
+  expect(l).toContain(666);
 });

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -1,8 +1,30 @@
+import * as digit from "./digit";
+import * as spec from "./spec";
+
+const searchers: spec.Interface[] = [digit.Searcher];
+
 // Search takes an arbitrary string and returns a list of any number found. The
 // first element of the list returned is the item being identified as number
 // with the highest certainty.
 export function Search(str: string): number[] {
-  let l: number[] = [];
+  let spl: string[] = [];
+  {
+    spl = str.split(" ");
+  }
 
-  return l;
+  let num: number[] = [];
+  for (let i = 0; i < spl.length; i++) {
+    let s: string = spl[i];
+
+    for (let i = 0; i < searchers.length; i++) {
+      let f: spec.Interface = searchers[i];
+      let r: spec.Result = f(s);
+
+      if (r.found === true) {
+        num.push(r.match);
+      }
+    }
+  }
+
+  return num;
 }

--- a/src/search/spec.ts
+++ b/src/search/spec.ts
@@ -1,0 +1,2 @@
+export type Result = { found: boolean; match: number };
+export type Interface = (s: string) => Result;


### PR DESCRIPTION
I would like to have a modular design implemented using separate searchers complying with a well defined interface. This adds the first `digit` searcher. 